### PR TITLE
Open notebook files with UTF-8 formatting

### DIFF
--- a/code/support_files/bake_notebooks.py
+++ b/code/support_files/bake_notebooks.py
@@ -9,7 +9,7 @@ def clean_unsolved_notebook(nb_file):
     1. Remove outputs from code cells
     2. Remove the answers from exercise cells
     """
-    nb_data = json.load(open(nb_file))
+    nb_data = json.load(open(nb_file, encoding="utf-8"))
 
     for i,cell in enumerate(nb_data['cells']):
         # remove outputs from all code cells
@@ -26,7 +26,7 @@ def clean_unsolved_notebook(nb_file):
                 remove_answers_from_exercise(nb_data['cells'][i+1:])
 
     # Write changes back to notebook
-    with open(nb_file, 'w') as fh:
+    with open(nb_file, 'w', encoding="utf-8") as fh:
         json.dump(nb_data, fh, indent=2)
 
 
@@ -39,7 +39,7 @@ def update_styles_in_notebook(nb_file):
     We do this because there is not a reliable way to define CSS class
     styles in notebooks; we must manually set the style of each cell.
     """
-    nb_data = json.load(open(nb_file))
+    nb_data = json.load(open(nb_file, encoding="utf-8"))
     for cell in nb_data['cells']:
         if cell['cell_type'] != 'markdown':
             continue
@@ -56,7 +56,7 @@ def update_styles_in_notebook(nb_file):
 
     # Overwrite notebook with modified styles 
     nb_json = json.dumps(nb_data, indent=2)
-    with open(nb_file, 'w') as f:
+    with open(nb_file, 'w', encoding="utf-8") as f:
         f.write(nb_json)
 
 
@@ -201,8 +201,8 @@ def set_md_style(source_lines):
 #     new_path = os.path.split(new_filename)[0]
 #     old_path = os.path.split(old_filename)[0]
 
-#     text = open(new_filename).read()
-#     with open(new_filename, 'w') as f:
+#     text = open(new_filename, encoding="utf-8").read()
+#     with open(new_filename, 'w', encoding="utf-8") as f:
 #         while True:
 #             m = re.match(r'(.*["\'])([^"\']*support_files[^"\']*)(["\'].*)', text, re.DOTALL)
 #             if m is None:
@@ -216,9 +216,9 @@ def set_md_style(source_lines):
 
 
 def replace(filename, search, replace):
-    text = open(filename).read()
+    text = open(filename, encoding="utf-8").read()
     text = text.replace(search, replace)
-    with open(filename, 'w') as f:
+    with open(filename, 'w', encoding="utf-8") as f:
         f.write(text)
 
 
@@ -245,7 +245,7 @@ def check_notebook_errors(nb_file):
     """Check for cell outputs that contain an error,
     unless the last line of the code cell contains "raises an exception"
     """
-    nb_data = json.load(open(nb_file))
+    nb_data = json.load(open(nb_file, encoding="utf-8"))
     for cell in nb_data['cells']:
         if cell['cell_type'] != 'code' or 'raises an exception' in cell['source'][-1].lower():
             continue


### PR DESCRIPTION
Previously, the bake script would open notebook files (on windows)
using the `windows1252` text encoding, then writing back to those
same files with `UTF-8` encoding. This causes problems when there
are special characters outside of the core ASCII block of code
points (such as zero-width spaces, causing the problems in this
case). These characters are not common between the encodings, so
when read incorrectly by one encoding and then written by the other,
the characters change. Because one character usually changes into
multiple characters, the badness multiplies upon multiple passes
of reads and writes.

Now we consistently open notebooks with UTF-8 format on both reads
and writes so that there are no character translation issues between
encodings.

Commits:
- **Fix f-string in `bake_notebooks.py`**
- **Open `ipynb` notebooks with UTF-8 encoding**
